### PR TITLE
Adds in support for getting the system id of the BLE device.

### DIFF
--- a/Smartlink/src/main/java/lib/smartlink/BLEService.java
+++ b/Smartlink/src/main/java/lib/smartlink/BLEService.java
@@ -32,7 +32,6 @@ import android.bluetooth.BluetoothGattCharacteristic;
 import android.util.Log;
 
 import java.lang.ref.WeakReference;
-import java.nio.ByteBuffer;
 import java.util.HashMap;
 
 /**

--- a/Smartlink/src/main/java/lib/smartlink/BLEService.java
+++ b/Smartlink/src/main/java/lib/smartlink/BLEService.java
@@ -32,6 +32,7 @@ import android.bluetooth.BluetoothGattCharacteristic;
 import android.util.Log;
 
 import java.lang.ref.WeakReference;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 
 /**
@@ -103,6 +104,12 @@ public abstract class BLEService {
     protected Integer getUin16ValueForCharacteristic(String characteristic) {
         BluetoothGattCharacteristic c = mFields.get(characteristic);
         return c.getIntValue(BluetoothGattCharacteristic.FORMAT_UINT16, 0);
+    }
+
+    protected Long get64bitValueForCharacteristic(String characteristic){
+        BluetoothGattCharacteristic c = mFields.get(characteristic);
+        Long l = ByteBuffer.wrap(this.getBytesForCharacteristic(characteristic)).getLong();
+        return l;
     }
 
     protected byte[] getBytesForCharacteristic(String characteristic) {

--- a/Smartlink/src/main/java/lib/smartlink/BLEService.java
+++ b/Smartlink/src/main/java/lib/smartlink/BLEService.java
@@ -106,12 +106,6 @@ public abstract class BLEService {
         return c.getIntValue(BluetoothGattCharacteristic.FORMAT_UINT16, 0);
     }
 
-    protected Long get64bitValueForCharacteristic(String characteristic){
-        BluetoothGattCharacteristic c = mFields.get(characteristic);
-        Long l = ByteBuffer.wrap(this.getBytesForCharacteristic(characteristic)).getLong();
-        return l;
-    }
-
     protected byte[] getBytesForCharacteristic(String characteristic) {
         BluetoothGattCharacteristic c = mFields.get(characteristic);
         return c.getValue();

--- a/Smartlink/src/main/java/lib/smartlink/BluetoothDevice.java
+++ b/Smartlink/src/main/java/lib/smartlink/BluetoothDevice.java
@@ -378,21 +378,10 @@ public class BluetoothDevice extends BluetoothGattCallback implements BluetoothA
         }
     }
 
-    private static String bytesToHex(byte[] bytes) {
-        final char[] hexArray = "0123456789ABCDEF".toCharArray();
-        char[] hexChars = new char[bytes.length * 2];
-        for (int j = 0; j < bytes.length; j++) {
-            int v = bytes[j] & 0xFF;
-            hexChars[j * 2] = hexArray[v >>> 4];
-            hexChars[j * 2 + 1] = hexArray[v & 0x0F];
-        }
-        return new String(hexChars);
-    }
-
     private static boolean uuidEqualToByteArray(UUID uuid, byte[] b) {
         // http://stackoverflow.com/questions/18019161/startlescan-with-128-bit-uuids-doesnt-work-on-native-android-ble-implementation
         final String s = uuid.toString().replace("-", "");
-        final String given = bytesToHex(b);
+        final String given = Util.bytesToHex(b);
 
         return given.equalsIgnoreCase(s);
     }

--- a/Smartlink/src/main/java/lib/smartlink/Util.java
+++ b/Smartlink/src/main/java/lib/smartlink/Util.java
@@ -50,4 +50,20 @@ public class Util {
             --rightPtr;
         }
     }
+
+    /**
+     * Converts a byte array to a hex string
+     * @param bytes bytes for string
+     * @return hex string
+     */
+    public static String bytesToHex(byte[] bytes) {
+        final char[] hexArray = "0123456789ABCDEF".toCharArray();
+        char[] hexChars = new char[bytes.length * 2];
+        for (int j = 0; j < bytes.length; j++) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = hexArray[v >>> 4];
+            hexChars[j * 2 + 1] = hexArray[v & 0x0F];
+        }
+        return new String(hexChars);
+    }
 }

--- a/Smartlink/src/main/java/lib/smartlink/driver/BLEDeviceInformationService.java
+++ b/Smartlink/src/main/java/lib/smartlink/driver/BLEDeviceInformationService.java
@@ -32,6 +32,7 @@ import android.util.Log;
 import java.lang.ref.WeakReference;
 
 import lib.smartlink.BLEService;
+import lib.smartlink.Util;
 
 /**
  * Created by pvaibhav on 17/02/2014.
@@ -41,18 +42,18 @@ public class BLEDeviceInformationService
     public interface Delegate {
         void didUpdateSerialNumber(BLEDeviceInformationService device, String serialNumber);
 
-        void didUpdateSystemID(BLEDeviceInformationService device, Long systemID);
+        void didUpdateSystemID(BLEDeviceInformationService device, String systemID);
     }
 
     private String mSerialNumber;
-    private Long mSystemID;
+    private String mSystemID;
     public WeakReference<Delegate> delegate;
 
     public String getSerialNumber() {
         return mSerialNumber;
     }
 
-    public Long getSystemID() {
+    public String getSystemID() {
         return mSystemID;
     }
 
@@ -73,7 +74,16 @@ public class BLEDeviceInformationService
                 Log.w("lib-smartlink-devinfo", "No delegate set");
             }
         } else if (c.equalsIgnoreCase("systemid")) {
-            mSystemID = get64bitValueForCharacteristic("systemid");
+            byte[] sysIDBytes = getBytesForCharacteristic("systemid");
+
+            byte[] newSysIDBytes = new byte[6];
+            System.arraycopy(sysIDBytes, 0, newSysIDBytes, 0, 3);
+            System.arraycopy(sysIDBytes, 5, newSysIDBytes, 3, 3);
+
+            Util.reverse(newSysIDBytes);
+
+            mSystemID = Util.bytesToHex(newSysIDBytes).toLowerCase();
+
             if (mSystemID != null)
                 Log.i("lib-smartlink-devinfo", "System ID updated: " + mSystemID);
 

--- a/Smartlink/src/main/java/lib/smartlink/driver/BLEDeviceInformationService.java
+++ b/Smartlink/src/main/java/lib/smartlink/driver/BLEDeviceInformationService.java
@@ -91,7 +91,7 @@ public class BLEDeviceInformationService
                 try {
                     delegate.get().didUpdateSystemID(this, mSystemID);
                 } catch (Exception ex) {
-                    Log.i("lib-smartlin-devinfo", "Error in delegate.");
+                    Log.i("lib-smartlink-devinfo", "Error in delegate.");
                 }
             }
         }

--- a/Smartlink/src/main/java/lib/smartlink/driver/BLEDeviceInformationService.java
+++ b/Smartlink/src/main/java/lib/smartlink/driver/BLEDeviceInformationService.java
@@ -29,9 +29,9 @@ package lib.smartlink.driver;
 
 import android.util.Log;
 
-import lib.smartlink.BLEService;
-
 import java.lang.ref.WeakReference;
+
+import lib.smartlink.BLEService;
 
 /**
  * Created by pvaibhav on 17/02/2014.
@@ -40,18 +40,26 @@ public class BLEDeviceInformationService
         extends BLEService {
     public interface Delegate {
         void didUpdateSerialNumber(BLEDeviceInformationService device, String serialNumber);
+
+        void didUpdateSystemID(BLEDeviceInformationService device, Long systemID);
     }
 
     private String mSerialNumber;
+    private Long mSystemID;
     public WeakReference<Delegate> delegate;
 
     public String getSerialNumber() {
         return mSerialNumber;
     }
 
+    public Long getSystemID() {
+        return mSystemID;
+    }
+
     @Override
     public void attached() {
         updateField("serialnumber");
+        updateField("systemid");
     }
 
     @Override
@@ -63,6 +71,18 @@ public class BLEDeviceInformationService
                 delegate.get().didUpdateSerialNumber(this, mSerialNumber);
             } catch (NullPointerException ex) {
                 Log.w("lib-smartlink-devinfo", "No delegate set");
+            }
+        } else if (c.equalsIgnoreCase("systemid")) {
+            mSystemID = get64bitValueForCharacteristic("systemid");
+            if (mSystemID != null)
+                Log.i("lib-smartlink-devinfo", "System ID updated: " + mSystemID);
+
+            if (delegate != null) {
+                try {
+                    delegate.get().didUpdateSystemID(this, mSystemID);
+                } catch (Exception ex) {
+                    Log.i("lib-smartlin-devinfo", "Error in delegate.");
+                }
             }
         }
     }


### PR DESCRIPTION
It doesn't appear that the serial number field is unique for the TailorToys BLE device. 

From the 

> **System ID** This field is a 64 bit number which uniquely identifies a particular device. It is built from a combination of the internal MAC address and other values. This value should be used as an identifier only, the actual value has no pattern to it and is not a “serial” number.

The information regarding this value, 0x2A23, can be found here: 
https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.system_id.xml

I added in another method to BLEService, get64bitValueForCharacteristic, to get the 64bit value into a long.
